### PR TITLE
soonho/login - v1.1_jwt 및 쿠키 생성

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,6 @@
 const express = require("express");
 require("dotenv").config();
+const cookieParser = require("cookie-parser");
 const userRouter = require("./Routes/Users");
 const cors = require("cors");
 const corsOption = require("./cors");
@@ -14,5 +15,6 @@ app.listen(process.env.PORT, () => {
 
 app.use(cors(corsOption));
 app.use(express.json());
+app.use(cookieParser());
 
 app.use("/users", userRouter);

--- a/Control/UsersController.js
+++ b/Control/UsersController.js
@@ -2,20 +2,27 @@ const usersService = require("../Service/Users/UserService");
 const { generateToken } = require("../Service/Users/Jwt");
 const { StatusCodes } = require("http-status-codes");
 
-// 회원가입
-const signUp = async (req, res) => {
-  const { nickname, email, password } = req.body;
-  // firebase 유저 불러오기
-  const user = await usersService.signUp(nickname, email, password);
+// 로그인
+const login = async (req, res) => {
+  try {
+    const { userId } = req.body;
 
-  // create token
-  const userToken = generateToken(user.id);
+    const authToken = await usersService.login(userId);
 
-  res.cookie("token", userToken, { httpOnly: true });
+    if (authToken) {
+      //create token
+      const userToken = generateToken(authToken);
+      console.log("userToken:", userToken);
 
-  return res.status(StatusCodes.OK).json({
-    nickname: user.nickname,
-  });
+      res.cookie("token", userToken, {
+        // js파일로 접근 불가
+        httpOnly: true,
+      });
+      return res.status(StatusCodes.OK).end();
+    }
+  } catch (error) {
+    return res.status(StatusCodes.BAD_REQUEST).end({ error: error.message });
+  }
 };
 
 // 소셜 로그인(파이어 베이스)
@@ -25,4 +32,4 @@ const socialLogin = (req, res) => {
   res.status(200).json(result);
 };
 
-module.exports = { socialLogin, signUp };
+module.exports = { socialLogin, login };

--- a/Feature/Authorization.js
+++ b/Feature/Authorization.js
@@ -1,0 +1,29 @@
+// jwt 모듈 소환
+const jwt = require("jsonwebtoken");
+
+const ensureAuthorization = (req, res) => {
+  try {
+    const receivedJWT = req.headers.authorization;
+    console.log("receivedJWT:", receivedJWT);
+
+    if (receivedJWT) {
+      const decodedJWT = jwt.verify(
+        receivedJWT,
+        process.env.JWT_ENCRIPTION_KEY
+      );
+      //{ foo: 'bar', iat: 1746283758 } iat(issued at):발행 시간
+
+      console.log(decodedJWT);
+      return parseInt(decodedJWT.id);
+    } else {
+      throw new ReferenceError("jwt must be provided");
+    }
+  } catch (err) {
+    console.log(err.name);
+    console.log(err.message);
+
+    return err;
+  }
+};
+
+module.exports = ensureAuthorization;

--- a/Routes/Users.js
+++ b/Routes/Users.js
@@ -2,7 +2,7 @@ const express = require("express");
 // const { param, validationResult } = require("express-validator");
 const userController = require("../Control/UsersController");
 const { body, validationResult } = require("express-validator");
-
+const { StatusCodes } = require("http-status-codes");
 const router = express.Router();
 
 //함수의 모듈화
@@ -14,35 +14,32 @@ const validation = (req, res, next) => {
   if (err.isEmpty()) {
     next();
   } else {
-    return res.status(400).json(err.array());
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      validateError: err.array(),
+    });
   }
 };
 
-// 일반 회원가입
-router.post(
-  "/sign-up",
-  [
-    body("nickname").notEmpty().isString().withMessage("닉네임을 입력해주세요"),
-
-    body("email")
-      .notEmpty()
-      .isEmail()
-      .withMessage("제대로 된 이메일 형식을 입력하세요"),
-
-    body("password")
-      .notEmpty()
-      .isString()
-      .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*]).{8,}$/)
-      .withMessage(
-        "총 8자 이상으로 작성해야 하며, 대문자 및 특수문자 1개를 반드시 포함해야 합니다."
-      ),
-
-    validation,
-  ],
-  userController.signUp
-);
+// body("password")
+//   .notEmpty()
+//   .isString()
+//   .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*]).{8,}$/)
+//   .withMessage(
+//     "총 8자 이상으로 작성해야 하며, 대문자 및 특수문자 1개를 반드시 포함해야 합니다."
+//   ),
 
 // 일반 로그인
+router.post(
+  "/login",
+  [
+    body("userId")
+      .notEmpty()
+      .isString()
+      .withMessage("문자열 ID값을 입력해주세요."),
+    validation,
+  ],
+  userController.login
+);
 
 // 소셜 로그인
 router.post("/sign-up/social-login", userController.socialLogin);

--- a/Service/Users/UserService.js
+++ b/Service/Users/UserService.js
@@ -1,23 +1,12 @@
-const {
-  createUserWithEmailAndPassword,
-  updateProfile,
-} = require("firebase/auth");
 const auth = require("../../FirebaseAdmin");
 
-// 회원 가입
-const signUp = async (nickname, email, password) => {
+const login = async (userId) => {
   try {
-    const user = await auth.createUser({
-      email: email,
-      password: password,
-      displayName: nickname,
-    });
-
-    return { id: user.uid, nickname: user.displayName };
+    const result = await auth.getUser(userId);
+    return result.uid;
   } catch (error) {
-    const errorCode = error.code;
-    const errorMessage = error.message;
-    console.log(errorCode, ":", errorMessage);
+    console.log(error.code, ":", error.message);
+    throw new Error("에러 발생");
   }
 };
 
@@ -28,4 +17,4 @@ const serviceSocialLogin = () => {
   return result;
 };
 
-module.exports = { serviceSocialLogin, signUp };
+module.exports = { serviceSocialLogin, login };

--- a/guide line.txt
+++ b/guide line.txt
@@ -1,0 +1,16 @@
+
+클라이언트에서 보낸 쿠키값은 어떻게 받아야 하나?
+
+현재 서버에서 
+   res.cookie("token", userToken, {
+        // js파일로 접근 불가
+        httpOnly: true,
+      });
+설정이 되어 있기에 js파일로 접근이 불가
+=> httpOnly를 설정하면 api 호출마다 브라우저가 쿠키값을 자동으로 전송, 서버에서 cookie-parser 모듈을 통해
+받을 수 있음
+
+설치	npm i cookie-parser
+등록	app.use(cookieParser());
+사용	req.cookies.token
+CORS 필수	credentials: true 양쪽에서 설정

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
@@ -1350,6 +1351,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",


### PR DESCRIPTION
기존 서버에서 회원 가입 및 로그인을 진행하려고 했으나, server에 firebase admin모듈로는 password값이 저장되지 않으며 로그인 시에도 단순 이메일 및 UID로 검사를 진행하기에 보안에 취약함

변경
- 회원가입
클라이언트에서 진행
- 로그인
클라이언트에서 로그인에 성공하면 유저 ID값을 서버에 전송하여 한번 더 인증 후 JWT 토큰을 Authorization 생성

주의: 쿠키값은 httpOnly로 설정되어 클라이언트에서 확인 불가 => API 호출 시 브라우저에서 자동으로 전송되기에 서버에서는 cookie-parser를 통해서 Authorization을 진행